### PR TITLE
Frequency account type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.33.0"
+version = "1.34.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -641,6 +641,15 @@
       "website": "https://polkadex.trade"
     },
     {
+      "prefix": 90,
+      "network": "frequency",
+      "displayName": "Frequency",
+      "symbols": ["FRQCY"],
+      "decimals": [8],
+      "standardAccount": "*25519",
+      "website": "https://www.frequency.xyz"
+    },
+    {
       "prefix": 92,
       "network": "anmol",
       "displayName": "Anmol Network",


### PR DESCRIPTION
The purpose of this PR is to add a Frequency account type to SS58

NOTE: This is just to spot check changes, the actual PR to merge into paritytech/ss58-registry will be mirrored from this one